### PR TITLE
[#145211537] Container versioning

### DIFF
--- a/hooks/README.md
+++ b/hooks/README.md
@@ -1,0 +1,8 @@
+# Hooks
+
+This directory contains [custom build phase hooks][hooks] that are used by
+automated builds on [Docker Hub][] and [Docker Cloud][].
+
+[hooks]: https://docs.docker.com/docker-cloud/builds/advanced/#custom-build-phase-hooks) 
+[Docker Hub]: https://hub.docker.com/
+[Docker Cloud]: https://cloud.docker.com/

--- a/hooks/post_push
+++ b/hooks/post_push
@@ -1,0 +1,7 @@
+#!/bin/bash
+set -eu
+
+# Create an immutable tag that we can reference.
+echo "Creating tag: ${SOURCE_COMMIT}"
+docker tag "${IMAGE_NAME}" "${DOCKER_REPO}:${SOURCE_COMMIT}"
+docker push "${DOCKER_REPO}:${SOURCE_COMMIT}"

--- a/hooks/post_push
+++ b/hooks/post_push
@@ -1,6 +1,10 @@
 #!/bin/bash
 set -eu
 
+# Docker Hub doesn't have this (but Docker Cloud might).
+export SOURCE_COMMIT
+SOURCE_COMMIT="${SOURCE_COMMIT:-$(git rev-parse HEAD)}"
+
 # Create an immutable tag that we can reference.
 echo "Creating tag: ${SOURCE_COMMIT}"
 docker tag "${IMAGE_NAME}" "${DOCKER_REPO}:${SOURCE_COMMIT}"

--- a/hooks/post_push
+++ b/hooks/post_push
@@ -5,7 +5,11 @@ set -eu
 export SOURCE_COMMIT
 SOURCE_COMMIT="${SOURCE_COMMIT:-$(git rev-parse HEAD)}"
 
-# Create an immutable tag that we can reference.
-echo "Creating tag: ${SOURCE_COMMIT}"
-docker tag "${IMAGE_NAME}" "${DOCKER_REPO}:${SOURCE_COMMIT}"
-docker push "${DOCKER_REPO}:${SOURCE_COMMIT}"
+# Create an immutable tag that we can reference for merge commits on "master".
+if [ "${SOURCE_BRANCH}" = "gds_master" ]; then
+  echo "Creating additional tag: ${SOURCE_COMMIT}"
+  docker tag "${IMAGE_NAME}" "${DOCKER_REPO}:${SOURCE_COMMIT}"
+  docker push "${DOCKER_REPO}:${SOURCE_COMMIT}"
+else
+  echo "Not creating tag for branch: ${SOURCE_BRANCH}"
+fi


### PR DESCRIPTION
## What

This is a cherry-pick of alphagov/paas-docker-cloudfoundry-tools#93 for Concourse resources that we've forked.

NB: This repo was previously using a branch called `gds` unlike all of our other forks which use `gds_master`. I've corrected this by:

1. Pushing a `gds_master` branch from the same commit ref as `gds`
1. Changing the Docker Hub build settings to use the `gds_master` branch for the `latest` tag
1. Changing the GitHub repo setting to use `gds_master` as the default branch

## How to review

1. Code review
1. You could delete the `gds` branch after merging, if you wish

## Who can review

Not @dcarley