### PR TITLE
[#150512756] Re-add IAM support

### DIFF
--- a/check/check_test.go
+++ b/check/check_test.go
@@ -11,6 +11,8 @@ import (
 
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/aws/credentials"
+	"github.com/aws/aws-sdk-go/aws/credentials/ec2rolecreds"
+	"github.com/aws/aws-sdk-go/aws/ec2metadata"
 	"github.com/aws/aws-sdk-go/aws/session"
 	"github.com/aws/aws-sdk-go/service/s3"
 	"github.com/concourse/semver-resource/models"
@@ -54,7 +56,16 @@ var _ = Describe("Check", func() {
 
 			key = guid.String()
 
-			creds := credentials.NewStaticCredentials(accessKeyID, secretAccessKey, "")
+			var creds *credentials.Credentials
+			if useInstanceProfile == "" {
+				creds = credentials.NewStaticCredentials(accessKeyID, secretAccessKey, "")
+			} else {
+				creds = credentials.NewCredentials(
+					&ec2rolecreds.EC2RoleProvider{
+						Client: ec2metadata.New(session.New()),
+					},
+				)
+			}
 			awsConfig := &aws.Config{
 				Region:           aws.String(regionName),
 				Credentials:      creds,

--- a/in/in_test.go
+++ b/in/in_test.go
@@ -11,6 +11,8 @@ import (
 
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/aws/credentials"
+	"github.com/aws/aws-sdk-go/aws/credentials/ec2rolecreds"
+	"github.com/aws/aws-sdk-go/aws/ec2metadata"
 	"github.com/aws/aws-sdk-go/aws/session"
 	"github.com/aws/aws-sdk-go/service/s3"
 	"github.com/concourse/semver-resource/models"
@@ -55,7 +57,16 @@ var _ = Describe("In", func() {
 
 			key = guid.String()
 
-			creds := credentials.NewStaticCredentials(accessKeyID, secretAccessKey, "")
+			var creds *credentials.Credentials
+			if useInstanceProfile == "" {
+				creds = credentials.NewStaticCredentials(accessKeyID, secretAccessKey, "")
+			} else {
+				creds = credentials.NewCredentials(
+					&ec2rolecreds.EC2RoleProvider{
+						Client: ec2metadata.New(session.New()),
+					},
+				)
+			}
 			awsConfig := &aws.Config{
 				Region:           aws.String(regionName),
 				Credentials:      creds,


### PR DESCRIPTION
## What

IAM support was originally added in #2, but since then, upstream have
switched from using `github.com/mitchellh/goamz` to the official AWS
library (commit 9dee348). When we rebased against upstream, our changes got
lost with this switch.

This therefore re-introduces them based on the similar support we added
to the S3 resource(alphagov/paas-s3-resource#1).

## How to review

I have already created a bucket for testing this called `semver-resource-tsting-state`.

This can be tested by running the integration tests in this repo. Alternatively, this can be testind in the pielines by pointing the container at the `re_add_iam_support` tag in DockerHub.

The tests can be run on any VM with the necessary IAM role. To use the Concourse VM for this, do the following:

```
cd paas-cf
make dev ssh_concourse
wget https://storage.googleapis.com/golang/go1.8.3.linux-amd64.tar.gz
mkdir go1.8
tar -C go1.8 -xf go1.8.3.linux-amd64.tar.gz
export GOROOT=$HOME/go1.8/go
export PATH=$GOROOT/bin:$PATH
export GOPATH=$HOME/go
sudo apt-get install git
go get -d github.com/concourse/semver-resource
cd go/src/github.com/concourse/semver-resource
git remote add alphagov https://github.com/alphagov/paas-semver-resource
git fetch alphagov
git checkout alphagov/re_add_iam_support

export SEMVER_TESTING_BUCKET=semver-resource-testing-state
export SEMVER_TESTING_REGION=eu-west-1
export SEMVER_TESTING_USE_INSTANCE_PROFILE=1
sudo mount /tmp -o remount,exec
go test ./...
echo $?
```

To cleanup:
```
sudo mount /tmp -o remount,noexec
rm -rf $HOME/go1.8
rm -rf $HOME/go
rm $HOME/go1.8.3.linux-amd64.tar.gz
```

## Who can review

Not me.