### PR TITLE
update alpine version in use

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.8.3-alpine
+FROM golang:1.12-alpine3.9
 
 ENV CONCOURSE_CODE_PATH ${GOPATH}/src/github.com/concourse/semver-resource
 


### PR DESCRIPTION
This image uses a vulnerable version of alpine that does not have a root password set. This was discovered by Cyber Security.